### PR TITLE
Fix NaN%

### DIFF
--- a/src/components/MultiplePoll/utils.ts
+++ b/src/components/MultiplePoll/utils.ts
@@ -83,7 +83,7 @@ function countPercentage(results: Result[]): void {
   }
 
   for (let i = 0; i < votes.length; i++) {
-    results[i].percentage = Math.floor((votes[i] / sum) * 100)
+    results[i].percentage = sum === 0 ? 0 : Math.floor((votes[i] / sum) * 100)
   }
 }
 


### PR DESCRIPTION
When the poll has zero votes, it shows each option's percentage as "NaN%". Changing this line will display "0%" instead.